### PR TITLE
Fix momentum

### DIFF
--- a/examples/GCM_phase_diagram/Makefile
+++ b/examples/GCM_phase_diagram/Makefile
@@ -8,13 +8,17 @@ LN  := -L ../../lib
 
 LINKER = $(INC) $(LN) -lmd
 
-all: fluid_compression_gcm
+all: fluid_compression_gcm gcm_compression_density_increment
 			
 debug: CXXFLAGS = $(DCXXFLAGS)
-debug: fluid_compression_gcm
+debug: fluid_compression_gcm gcm_compression_density_increment
 
-fluid_compression_gcm: *.o $(LIB)/libmd.a
-	$(CXX) $(CXXFLAGS) *.o $(LINKER) -o fluid_compression_gcm -lstdc++fs
+gcm_compression_density_increment: gcm_compression_density_increment.o $(LIB)/libmd.a
+	$(CXX) $(CXXFLAGS) gcm_compression_density_increment.o $(LINKER) -o gcm_compression_density_increment -lstdc++fs
+	mv gcm_compression_density_increment ../examplebin/
+
+fluid_compression_gcm: fluid_compression.o $(LIB)/libmd.a
+	$(CXX) $(CXXFLAGS) fluid_compression.o $(LINKER) -o fluid_compression_gcm -lstdc++fs
 	mv fluid_compression_gcm ../examplebin/
 
 %.o: %.cpp

--- a/examples/GCM_phase_diagram/gcm_compression_density_increment.cpp
+++ b/examples/GCM_phase_diagram/gcm_compression_density_increment.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include "helper_functions.h"
+#include "phase_transition.h"
+
+int main() {
+  std::string dir = "/home/gn/Desktop/md_data/compress_gcm";
+  size_t compress_steps = 100;
+  //todo: create a range density vector
+  //todo: loop through it one timestep at a time
+  /*
+    * This method effectively replaces timestep iterations with 
+    * density iterations by equating the compression timestep to 1
+    * 
+   */
+  phase_transition run(dir, compress_steps, true, 10, 6, "FCC", false, 0);
+  std::vector<double> temperatures = {0.001, 0.002, 0.003, 0.004, 0.005, 0.006};
+  for (int t = 0; t < temperatures.size(); ++t) {
+    run.crystallisation(0.05, 0.8, 0.001, temperatures[t], 0, 0, "GCM");
+  }
+}

--- a/src/MD.cpp
+++ b/src/MD.cpp
@@ -498,8 +498,8 @@ void MD::Simulation(double DENSITY, double TEMPERATURE, double POWER,
   _T0 = TEMPERATURE;
   dt = 0.005 / sqrt(_T0);  // Time-step, defined here and reused in the Verlet
   // Box length scaling
-  scale = pow((N / _rho), (1.0 / 3.0)) / pow(N, (1.0 / 3.0));
   L = pow((N / _rho), 1.0 / 3.0);
+  scale = L;
   Vol = N / _rho;
 
   // cut_off redefinition

--- a/src/MD.cpp
+++ b/src/MD.cpp
@@ -228,14 +228,12 @@ void MD::initialise(std::vector<double> &x, std::vector<double> &y,
   std::for_each(vy.begin(), vy.end(), [mean_vy](double &d) { d -= mean_vy; });
   std::for_each(vz.begin(), vz.end(), [mean_vz](double &d) { d -= mean_vz; });
 
-  // ! Check the values of mean_vx, mean_vy, mean_vz after a compression
   size_t i;
   // Temperature calculation, statistically
   KE = 0;
   for (i = 0; i < N; ++i) {
     KE += 0.5 * (vx[i] * vx[i] + vy[i] * vy[i] + vz[i] * vz[i]);
   }
-  // ! Check the value of KE after a compression
   T = KE / (1.5 * N);
   scale_v = sqrt(TEMPERATURE / T);  // scaling factor
 

--- a/src/MD.cpp
+++ b/src/MD.cpp
@@ -229,14 +229,7 @@ void MD::initialise(std::vector<double> &x, std::vector<double> &y,
   std::for_each(vz.begin(), vz.end(), [mean_vz](double &d) { d -= mean_vz; });
 
   // ! Check the values of mean_vx, mean_vy, mean_vz after a compression
-  size_t tempN = N;
   size_t i;
-  // Subtracting Av. velocities from each particle
-  for (i = 0; i < tempN; ++i) {
-    vx[i] = vx[i] - mean_vx;
-    vy[i] = vy[i] - mean_vy;
-    vz[i] = vz[i] - mean_vz;
-  }
   // Temperature calculation, statistically
   KE = 0;
   for (i = 0; i < N; ++i) {
@@ -247,7 +240,7 @@ void MD::initialise(std::vector<double> &x, std::vector<double> &y,
   scale_v = sqrt(TEMPERATURE / T);  // scaling factor
 
   // Velocity scaling
-  for (i = 0; i < tempN; ++i) {
+  for (i = 0; i < N; ++i) {
     vx[i] *= scale_v;
     vy[i] *= scale_v;
     vz[i] *= scale_v;
@@ -318,13 +311,18 @@ void MD::verlet_algorithm(std::vector<double> &rx, std::vector<double> &ry,
 
   size_t i;
   for (i = 0; i < N; ++i) {
+
+    // Step velocities forward in time
     vx[i] = vx[i] * scale_v + fx[i] * dt;
     vy[i] = vy[i] * scale_v + fy[i] * dt;
     vz[i] = vz[i] * scale_v + fz[i] * dt;
+
+    // Step positions forward in time
     rx[i] = rx[i] + vx[i] * dt;
     ry[i] = ry[i] + vy[i] * dt;
     rz[i] = rz[i] + vz[i] * dt;
 
+    // MSD stepping
     rrx[i] = rrx[i] + vx[i] * dt;
     rry[i] = rry[i] + vy[i] * dt;
     rrz[i] = rrz[i] + vz[i] * dt;

--- a/src/phase_transition.cpp
+++ b/src/phase_transition.cpp
@@ -15,7 +15,8 @@ void phase_transition::crystallisation(double DENSITY, double FINAL_DENSITY,
                                        std::string pp_type) {
   /*
    * Compress the fluid to get the phase boundary for a specific temperature.
-   *
+   * 
+   * ceil((FINAL_DENSITY - DENSITY) / DENSITY_INC) compressions of STEPS length
    * Performs repeated compresss of the fluid by periodically
    * incrementing the density of the fluid.
    * As a consequence the box length, the scaling factor and the
@@ -27,9 +28,9 @@ void phase_transition::crystallisation(double DENSITY, double FINAL_DENSITY,
   // todo: the POS << time_stamp stream will be a mess, same with RDF
   double current_rho = DENSITY;
   double old_box_length = 0;
-  // size_t compression_num = ceil((FINAL_DENSITY - DENSITY) / DENSITY_INC);
+
   try {
-    if (FINAL_DENSITY > DENSITY) {
+    if (FINAL_DENSITY > DENSITY) {  //todo: add compression rate sensitive case +/- sign
       std::runtime_error(
           "Final density has to be smaller than initial density");
     }


### PR DESCRIPTION
Fixed temperature spike at the beginning of a simulation, caused by artificial clustering introduced by bad scaling.
Also included an example with a varying density gradient.
Fixes #18